### PR TITLE
Add `allowInsecurePredicate` to fix CI

### DIFF
--- a/nix/ci/default.nix
+++ b/nix/ci/default.nix
@@ -89,6 +89,7 @@ in
               inherit system;
               nixpkgs = inputs."nixpkgs-${branch}";
               extraConfig = {
+                allowInsecurePredicate = x: true;
                 allowUnfree = true;
                 cudaSupport = true;
                 cudaEnableForwardCompat = cuda.forwardCompat;


### PR DESCRIPTION
Currently CI fails due to insecure packages https://hercules-ci.com/github/SomeoneSerge/nixpkgs-cuda-ci/jobs/10602